### PR TITLE
Library Layout, warning fixes, and designer fix

### DIFF
--- a/Bifrost.XAML.Phone/Bifrost.XAML.Phone.csproj
+++ b/Bifrost.XAML.Phone/Bifrost.XAML.Phone.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_PHONE_APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_PHONE_APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>
@@ -112,6 +114,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetPlatformIdentifier)' == '' ">
     <TargetPlatformIdentifier>WindowsPhoneApp</TargetPlatformIdentifier>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Bifrost.XAML.Phone/Controls/SplitView/SplitView.cs
+++ b/Bifrost.XAML.Phone/Controls/SplitView/SplitView.cs
@@ -43,7 +43,14 @@ namespace Bifrost.XAML.Phone.Controls
         {
             this.DefaultStyleKey = typeof(SplitView);
 
-            HardwareButtons.BackPressed += HardwareButtons_BackPressed;
+            try
+            {
+                HardwareButtons.BackPressed += HardwareButtons_BackPressed;
+            }
+            catch
+            {
+                // Ignore when the hardware buttons aren't available (to avoid a crashing designer)
+            }
         }
 
         void HardwareButtons_BackPressed(object sender, BackPressedEventArgs e)

--- a/Bifrost.XAML/Converters/DateTimeToDateTimeOffsetConverter.cs
+++ b/Bifrost.XAML/Converters/DateTimeToDateTimeOffsetConverter.cs
@@ -20,7 +20,7 @@ namespace Bifrost.XAML.Converters
                 DateTime date = (DateTime)value;
                 return new DateTimeOffset(date);
             }
-            catch (Exception ex)
+            catch
             {
                 return DateTimeOffset.MinValue;
             }
@@ -33,7 +33,7 @@ namespace Bifrost.XAML.Converters
                 DateTimeOffset dto = (DateTimeOffset)value;
                 return dto.DateTime;
             }
-            catch (Exception ex)
+            catch
             {
                 return DateTime.MinValue;
             }

--- a/Bifrost.XAML/Converters/DateTimeToTimeSpanConverter.cs
+++ b/Bifrost.XAML/Converters/DateTimeToTimeSpanConverter.cs
@@ -20,7 +20,7 @@ namespace Bifrost.XAML.Converters
                 DateTime date = (DateTime)value;
                 return date - date.Date;
             }
-            catch (Exception ex)
+            catch
             {
                 return TimeSpan.MinValue;
             }


### PR DESCRIPTION
This patch fixes 3 problems:
1. Generate library layout (which can be then consumed to create a NuGet package)
2. Fixed warnings
3. Ignore when the hardware buttons aren't available (to avoid a crashing designer)
